### PR TITLE
fix: handle undefined values in JSON.parse to prevent build errors

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,27 +5,41 @@ import { SolutionsSection } from "@/components/solutions/solutions-section";
 const Page = dynamic(() => import("../components/page").then(mod => mod.Page), { ssr: false });
 
 export default async function Home() {
-  const res = await client.queries.page({ relativePath: "home.mdx" });
-  const solutionsRes = await client.queries.solutionConnection();
+  try {
+    const res = await client.queries.page({ relativePath: "home.mdx" });
+    const solutionsRes = await client.queries.solutionConnection();
 
-  // Sanitiza os dados para garantir que são plain objects
-  const plainData = JSON.parse(JSON.stringify(res.data));
-  const plainQuery = typeof res.query === "string" ? res.query : JSON.parse(JSON.stringify(res.query));
-  const plainVariables = JSON.parse(JSON.stringify(res.variables));
-  
-  const plainSolutionsData = JSON.parse(JSON.stringify(solutionsRes.data));
-  const plainSolutionsQuery = typeof solutionsRes.query === "string" ? solutionsRes.query : JSON.parse(JSON.stringify(solutionsRes.query));
-  const plainSolutionsVariables = JSON.parse(JSON.stringify(solutionsRes.variables));
+    // Sanitiza os dados para garantir que são plain objects
+    const plainData = res?.data ? JSON.parse(JSON.stringify(res.data)) : {};
+    const plainQuery = res?.query ? (typeof res.query === "string" ? res.query : JSON.parse(JSON.stringify(res.query))) : "";
+    const plainVariables = res?.variables ? JSON.parse(JSON.stringify(res.variables)) : {};
+    
+    const plainSolutionsData = solutionsRes?.data ? JSON.parse(JSON.stringify(solutionsRes.data)) : {};
+    const plainSolutionsQuery = solutionsRes?.query ? (typeof solutionsRes.query === "string" ? solutionsRes.query : JSON.parse(JSON.stringify(solutionsRes.query))) : "";
+    const plainSolutionsVariables = solutionsRes?.variables ? JSON.parse(JSON.stringify(solutionsRes.variables)) : {};
 
-  return (
-    <>
-      <Page
-        // https://github.com/vercel/next.js/issues/47447
-        data={plainData}
-        query={plainQuery}
-        variables={plainVariables}
-      />
-      
-    </>
-  );
+    return (
+      <>
+        <Page
+          // https://github.com/vercel/next.js/issues/47447
+          data={plainData}
+          query={plainQuery}
+          variables={plainVariables}
+        />
+        
+      </>
+    );
+  } catch (error) {
+    console.error("Error loading home page data:", error);
+    // Return a fallback page with empty data
+    return (
+      <>
+        <Page
+          data={{}}
+          query=""
+          variables={{}}
+        />
+      </>
+    );
+  }
 }

--- a/app/solucoes/[slug]/page.tsx
+++ b/app/solucoes/[slug]/page.tsx
@@ -8,23 +8,29 @@ type Props = {
 }
 
 export default async function SolutionPage({ params }: Props) {
-  const tinaProps = await client.queries.solution({ relativePath: `${params.slug}.mdx` });
-  const solutionsRes = await client.queries.solutionConnection();
+  try {
+    const tinaProps = await client.queries.solution({ relativePath: `${params.slug}.mdx` });
+    const solutionsRes = await client.queries.solutionConnection();
 
-  // Sanitiza os dados para garantir que são plain objects
-  const plainTinaProps = {
-    data: JSON.parse(JSON.stringify(tinaProps.data)),
-    query: typeof tinaProps.query === "string" ? tinaProps.query : JSON.parse(JSON.stringify(tinaProps.query)),
-    variables: JSON.parse(JSON.stringify(tinaProps.variables)),
-  };
-  
-  const plainSolutionsProps = {
-    data: JSON.parse(JSON.stringify(solutionsRes.data)),
-    query: typeof solutionsRes.query === "string" ? solutionsRes.query : JSON.parse(JSON.stringify(solutionsRes.query)),
-    variables: JSON.parse(JSON.stringify(solutionsRes.variables)),
-  };
+    // Sanitiza os dados para garantir que são plain objects
+    const plainTinaProps = {
+      data: tinaProps?.data ? JSON.parse(JSON.stringify(tinaProps.data)) : {},
+      query: tinaProps?.query ? (typeof tinaProps.query === "string" ? tinaProps.query : JSON.parse(JSON.stringify(tinaProps.query))) : "",
+      variables: tinaProps?.variables ? JSON.parse(JSON.stringify(tinaProps.variables)) : {},
+    };
+    
+    const plainSolutionsProps = {
+      data: solutionsRes?.data ? JSON.parse(JSON.stringify(solutionsRes.data)) : {},
+      query: solutionsRes?.query ? (typeof solutionsRes.query === "string" ? solutionsRes.query : JSON.parse(JSON.stringify(solutionsRes.query))) : "",
+      variables: solutionsRes?.variables ? JSON.parse(JSON.stringify(solutionsRes.variables)) : {},
+    };
 
-  return <SolutionPageTemplate {...plainTinaProps} solutions={plainSolutionsProps} />
+    return <SolutionPageTemplate {...plainTinaProps} solutions={plainSolutionsProps} />
+  } catch (error) {
+    console.error("Error loading solution page data:", error);
+    // Return a fallback page with empty data
+    return <SolutionPageTemplate data={{}} query="" variables={{}} solutions={{ data: {}, query: "", variables: {} }} />
+  }
 }
 
 export async function generateStaticParams() {


### PR DESCRIPTION
Added null checks and try-catch blocks to handle cases where TinaCMS queries return undefined values. This prevents JSON.parse from failing with 'undefined is not valid JSON' error during static generation.

- Added error handling in app/page.tsx
- Added error handling in app/solucoes/[slug]/page.tsx
- Return fallback data when queries fail