### PR TITLE
fix: change default branch from 'main' to 'master' in TinaCMS config

### DIFF
--- a/tina/config.tsx
+++ b/tina/config.tsx
@@ -6,7 +6,7 @@ import { FAQCollection } from "./collections/faq";
 import { SolutionCollection } from "./collections/solution";
 import { CalculatorCollection } from "./collections/calculator";
 
-const branch = process.env.GITHUB_BRANCH || process.env.VERCEL_GIT_COMMIT_REF || "main";
+const branch = process.env.GITHUB_BRANCH || process.env.VERCEL_GIT_COMMIT_REF || "master";
 
 export default defineConfig({
   token:  process.env.TINA_TOKEN, // This should match the value in your .env file


### PR DESCRIPTION
The repository uses 'master' as the default branch, not 'main'. This was causing 403 errors and GraphQL schema not found errors.